### PR TITLE
Rename is_admin column to admin

### DIFF
--- a/db/migrate/20201203100656_rename_user_admin_column.rb
+++ b/db/migrate/20201203100656_rename_user_admin_column.rb
@@ -1,0 +1,5 @@
+class RenameUserAdminColumn < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :users, :is_admin, :admin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_02_161459) do
+ActiveRecord::Schema.define(version: 2020_12_03_100656) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -144,7 +144,7 @@ ActiveRecord::Schema.define(version: 2020_12_02_161459) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "nickname"
     t.string "address"
-    t.boolean "is_admin"
+    t.boolean "admin"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -91,14 +91,14 @@ USERS_NAMES.each do |username|
     nickname: username,
     password: '123456',
     password_confirmation: '123456',
-    is_admin: username == 'admin'
+    admin: username == 'admin'
   )
 end
 
 # Create random list's contents and reviews
 p "Create random lists contents and reviews"
 User.all.each do |user|
-  break if user.is_admin
+  break if user.admin
   user.lists.each do |list|
     5.times do
       idx_beer = rand(Beer.first.id...Beer.last.id)


### PR DESCRIPTION
In table users, rename the column is_admin to admin.

Some changes in the seed file to use the new column name.